### PR TITLE
WIP: Add sysctl config to globally disable IPv6

### DIFF
--- a/debian/01-ubports-disable-ipv6.conf
+++ b/debian/01-ubports-disable-ipv6.conf
@@ -1,0 +1,2 @@
+net.ipv6.conf.all.disable_ipv6 = 1
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.2.2-1ubports2) xenial; urgency=medium
+
+  * Disable IPv6 globally 
+
+ -- Florian Leeber <florian@ubports.com>  Thu, 19 Jun 2020 17:57:31 +0100
+
 network-manager (1.2.2-1ubports1) xenial; urgency=medium
 
   * Import to UBports 

--- a/debian/network-manager.install
+++ b/debian/network-manager.install
@@ -28,3 +28,4 @@ debian/NetworkManager.conf etc/NetworkManager/
 debian/org.freedesktop.NetworkManager.pkla var/lib/polkit-1/localauthority/10-vendor.d/
 debian/60-network-manager.rules usr/share/polkit-1/rules.d/
 debian/source_network-manager.py /usr/share/apport/package-hooks/
+debian/01-ubports-disable-ipv6.conf etc/sysctl.d/


### PR DESCRIPTION
Since Ubuntu Touch currently has issues with supporting IPv6 on most phones, disable it for the moment until we find a better solution. Resolves https://github.com/ubports/ubuntu-touch/issues/116 for the moment...
