### PR TITLE
Fix EINVAL when adding IPv6 address on older kernels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+network-manager (1.2.2-1ubports3) xenial; urgency=medium
+
+  [Lubomir Rintel]
+  * Fix setting of IFA_ADDRESS without a peer 
+
+  [Florian Leeber]
+  * Do not use extended IFA flags if the kernel does not support it
+
+ -- Florian Leeber <florian@ubports.com>  Tue, 07 Jul 2020 21:59:39 +0200
+
 network-manager (1.2.2-1ubports1) xenial; urgency=medium
 
   * Import to UBports 

--- a/debian/patches/Do-not-add-extended-IFA-flags-if-the-kernel-does-not.patch
+++ b/debian/patches/Do-not-add-extended-IFA-flags-if-the-kernel-does-not.patch
@@ -1,0 +1,39 @@
+From a60bcaf16ece9b35478f961cfe005c00e5e22692 Mon Sep 17 00:00:00 2001
+From: Florian Leeber <florian@ubports.com>
+Date: Fri, 10 Jul 2020 21:54:55 +0200
+Subject: [PATCH] Do not add extended IFA flags if the kernel does not support
+ them This became necessary for older Android kernels as they still return
+ EINVAL (see comment in original code) and we cannot patch all of them.
+
+---
+ src/platform/nm-linux-platform.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/platform/nm-linux-platform.c b/src/platform/nm-linux-platform.c
+index 5817ef0..96987c7 100644
+--- a/src/platform/nm-linux-platform.c
++++ b/src/platform/nm-linux-platform.c
+@@ -2134,6 +2134,8 @@ nla_put_failure:
+ 	g_return_val_if_reached (NULL);
+ }
+ 
++static gboolean _support_kernel_extended_ifa_flags_get (void);
++
+ /* Copied and modified from libnl3's build_addr_msg(). */
+ static struct nl_msg *
+ _nl_msg_new_address (int nlmsg_type,
+@@ -2212,9 +2214,9 @@ _nl_msg_new_address (int nlmsg_type,
+ 		NLA_PUT (msg, IFA_CACHEINFO, sizeof(ca), &ca);
+ 	}
+ 
+-	if (flags & ~((guint32) 0xFF)) {
++	if ((flags & ~((guint32) 0xFF)) && _support_kernel_extended_ifa_flags_get()) {
+ 		/* only set the IFA_FLAGS attribute, if they actually contain additional
+-		 * flags that are not already set to am.ifa_flags.
++		 * flags that are not already set to am.ifa_flags and the kernel supports it.
+ 		 *
+ 		 * Older kernels refuse RTM_NEWADDR and RTM_NEWROUTE messages with EINVAL
+ 		 * if they contain unknown netlink attributes. See net/core/rtnetlink.c, which
+-- 
+2.17.1
+

--- a/debian/patches/platform-linux-fix-setting-of-IFA_ADDRESS-wo-peer.patch
+++ b/debian/patches/platform-linux-fix-setting-of-IFA_ADDRESS-wo-peer.patch
@@ -1,0 +1,34 @@
+From e2409b1888d9c720805bed6522d44102f16458f0 Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Sun, 3 Feb 2019 21:40:53 +0100
+Subject: [PATCH] platform/linux: fix setting of IFA_ADDRESS without a peer
+
+Since commit 9ecdba316 ('platform: create netlink messages directly
+without libnl-route-3') we're unconditionally setting IFA_ADDRESS to
+the peer address, even if there's no peer and it's all zeroes.
+
+The kernel actually stopped caring somewhere around commit caeaba790
+('ipv6: add support of peer address') in v3.10, but Ubuntu Touch likes
+to run Android's v3.4 on some poorly supported hardware.
+
+Fixes: 9ecdba316cf89612f3441aad16b99edc01c24e0d
+
+https://gitlab.freedesktop.org/NetworkManager/NetworkManager/merge_requests/77
+(cherry picked from commit ef6d461b7f07cde64a0b7271df0fb2a897838f8b)
+---
+ src/platform/nm-linux-platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/platform/nm-linux-platform.c b/src/platform/nm-linux-platform.c
+index 5817ef0..092fe9e 100644
+--- a/src/platform/nm-linux-platform.c
++++ b/src/platform/nm-linux-platform.c
+@@ -5434,7 +5439,7 @@ ip6_address_add (NMPlatform *platform,
+ 	                             ifindex,
+ 	                             &addr,
+ 	                             plen,
+-	                             &peer_addr,
++	                             IN6_IS_ADDR_UNSPECIFIED (&peer_addr) ? NULL : &peer_addr,
+ 	                             flags,
+ 	                             RT_SCOPE_UNIVERSE,
+ 	                             lifetime,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,4 +29,5 @@ Fix-openvpn-by-handling-do_add_route-EEXISTS.patch
 wwan-fix-ofono-connection-problems.patch
 Add-statistics-interface.patch
 secret-agent-fix-get-secrets-timeout.patch
-
+platform-linux-fix-setting-of-IFA_ADDRESS-wo-peer.patch
+Do-not-add-extended-IFA-flags-if-the-kernel-does-not.patch


### PR DESCRIPTION
That was a tricky one: EINVAL is caused by unsupported extended IFA_FLAGS on older kernels. Ignoring them in case of IPv6 should not have a real consequence, only that it could mess with privacy extensions. But this we need to test a bit.