### PR TITLE
Drop autoconnect attempts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+network-manager (1.2.2-1ubports4) xenial; urgency=medium
+
+  [Jos√ Pekkarinen]
+  * Remove connection attempts to unconfigured wifi
+
+ -- Jos√ Pekkarinen <jose.pekkarinen@foxhound.fi>  Thu, 27 May 2021 11:23:20 +0300
+
 network-manager (1.2.2-1ubports3) xenial; urgency=medium
 
   [Lubomir Rintel]

--- a/debian/patches/Remove-auth-attempt-if-connection-has-failed.patch
+++ b/debian/patches/Remove-auth-attempt-if-connection-has-failed.patch
@@ -1,0 +1,21 @@
+Index: NetworkManager-1.2.2/src/devices/wifi/nm-device-wifi.c
+===================================================================
+--- NetworkManager-1.2.2.orig/src/devices/wifi/nm-device-wifi.c
++++ NetworkManager-1.2.2/src/devices/wifi/nm-device-wifi.c
+@@ -2144,12 +2129,10 @@ supplicant_connection_timeout_cb (gpoint
+ 		if (nm_settings_connection_get_timestamp (nm_act_request_get_settings_connection (req), &timestamp))
+ 			new_secrets = !timestamp;
+ 
+-		if (handle_auth_or_fail (self, req, new_secrets) == NM_ACT_STAGE_RETURN_POSTPONE)
+-			_LOGW (LOGD_DEVICE | LOGD_WIFI, "Activation: (wifi) asking for new secrets");
+-		else {
+-			nm_device_state_changed (device, NM_DEVICE_STATE_FAILED,
+-			                         NM_DEVICE_STATE_REASON_NO_SECRETS);
+-		}
++		if (timestamp)
++			_LOGW (LOGD_DEVICE | LOGD_WIFI, "Activation: (wifi) secrets may no longer be valid");
++		nm_device_state_changed (device, NM_DEVICE_STATE_FAILED,
++					 NM_DEVICE_STATE_REASON_NO_SECRETS);
+ 	} else {
+ 		_LOGW (LOGD_DEVICE | LOGD_WIFI,
+ 		       "Activation: (wifi) association took too long, failing activation");

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,3 +31,4 @@ Add-statistics-interface.patch
 secret-agent-fix-get-secrets-timeout.patch
 platform-linux-fix-setting-of-IFA_ADDRESS-wo-peer.patch
 Do-not-add-extended-IFA-flags-if-the-kernel-does-not.patch
+Remove-auth-attempt-if-connection-has-failed.patch


### PR DESCRIPTION
This patch removes automatic attempt
to connect right after a failure to
any wifi available, which often triggers
a passwrod prompt for the automatically
configured open wifi networks nearby.

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>