### PR TITLE
Remove password prompt on single assoc failure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+network-manager (1.2.2-1ubports5) xenial; urgency=medium
+
+  [José Pekkarinen]
+  * Clear wifi password after retries are over or explicit request
+
+ -- José Pekkarinen <jose.pekkarinen@foxhound.fi>  Sun, 17 Dec 2021 17:49:20 +0300
+
 network-manager (1.2.2-1ubports4) xenial; urgency=medium
 
   [José Pekkarinen]

--- a/debian/patches/handle_new_secrets_on_failure.patch
+++ b/debian/patches/handle_new_secrets_on_failure.patch
@@ -1,0 +1,21 @@
+--- a/src/devices/wifi/nm-device-wifi.c
++++ b/src/devices/wifi/nm-device-wifi.c
+@@ -1764,17 +1764,10 @@
+ 		nm_act_request_clear_secrets (req);
+ 
+ 		_LOGI (LOGD_DEVICE | LOGD_WIFI,
+-		       "Activation: (wifi) disconnected during association, asking for new key");
++		       "Activation: (wifi) disconnected during association");
+ 
+ 		cleanup_association_attempt (self, TRUE);
+ 		nm_device_state_changed (device, NM_DEVICE_STATE_NEED_AUTH, NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT);
+-		nm_act_request_get_secrets (req,
+-		                            setting_name,
+-		                            NM_SECRET_AGENT_GET_SECRETS_FLAG_ALLOW_INTERACTION
+-		                              | NM_SECRET_AGENT_GET_SECRETS_FLAG_REQUEST_NEW,
+-		                            NULL,
+-		                            wifi_secrets_cb,
+-		                            self);
+ 		handled = TRUE;
+ 	}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -32,3 +32,4 @@ secret-agent-fix-get-secrets-timeout.patch
 platform-linux-fix-setting-of-IFA_ADDRESS-wo-peer.patch
 Do-not-add-extended-IFA-flags-if-the-kernel-does-not.patch
 Remove-auth-attempt-if-connection-has-failed.patch
+handle_new_secrets_on_failure.patch


### PR DESCRIPTION
The patch removes a password prompt when a single
association fail.

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>